### PR TITLE
changes api_key reference from constant to variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Also, make sure that you have the [Guzzle](http://guzzlephp.org/index.html) libr
 The first thing you'll need to interact with the SproutVideo API is your API key.
 ```php
 <?php
-SproutVideo::api_key = 'abcd1234';
+SproutVideo::$api_key = 'abcd1234';
 ?>
 ```
 


### PR DESCRIPTION
The readme references a constant api_key but [it's actually a variable.](https://github.com/jaketoolson/sproutvideo-php/blob/master/lib/SproutVideo/SproutVideo.php#L5)
