### PR TITLE
multidimensional array

### DIFF
--- a/lib/SproutVideo/CurlClient.php
+++ b/lib/SproutVideo/CurlClient.php
@@ -59,7 +59,7 @@ class CurlClient
       curl_close($this->ch);
     }
 
-    return json_decode($result);
+    return json_decode($result, true);
   }
 
   public function get($uri, $options = null)


### PR DESCRIPTION
Currently, if the returned response is a nested object, the root is an array however the children remain an object.  Passing ```true``` coverts everything to an array.