### PR TITLE
CurlClient->delete: Notice: undefined $body

### DIFF
--- a/lib/SproutVideo/CurlClient.php
+++ b/lib/SproutVideo/CurlClient.php
@@ -79,7 +79,7 @@ class CurlClient
 
   public function delete($uri, $options = null)
   {
-    return $this->request('DELETE', $uri, $body, $options);
+    return $this->request('DELETE', $uri, null, $options);
   }
 
   public function upload($uri, $body, $options, $method = 'POST')


### PR DESCRIPTION
When the method delete calls $this->request the third parameter $body is undefined.
Passing null as the third parameter of $this->request works fine