### PR TITLE
Remove version, it creates problems

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "sproutvideo/sproutvideo",
-    "version": "1.3.3",
     "type": "library",
     "description": "A PHP client for SproutVideo (https://sproutvideo.com)",
     "keywords": ["video", "video hosting"],


### PR DESCRIPTION
See https://getcomposer.org/doc/04-schema.md#version, if Packagist or Composer can figure out the version from a repository because a commit is tagged, you should omit the version being mentioned in composer.json

The tag will only point to the one, defined commit. However, the version will exist in every commit after you changed it, stating that every commit is this version, which makes no sense. Composer allowed to include this information for cases where there is no other way to get the version information, e.g. if you work without a repo (or hide it from public view) and release some compiled release containing all composer metadata including the version.